### PR TITLE
Link appointment types with specialty

### DIFF
--- a/appointment_types.html
+++ b/appointment_types.html
@@ -16,12 +16,19 @@
   <form id="type-form">
     <input type="hidden" id="type-id">
     <label>Name <input id="type-name" required></label>
+    <label>Specialty
+      <select id="type-specialty">
+        <option>Speech Therapy</option>
+        <option>Psychology</option>
+        <option>Occupational Therapy</option>
+      </select>
+    </label>
     <label>Default Duration (minutes) <input type="number" id="type-duration" required></label>
     <button type="submit">Save</button>
   </form>
   <table id="types-table">
     <thead>
-      <tr><th>Name</th><th>Duration</th><th>Actions</th></tr>
+      <tr><th>Name</th><th>Specialty</th><th>Duration</th><th>Actions</th></tr>
     </thead>
     <tbody></tbody>
   </table>

--- a/appointments.html
+++ b/appointments.html
@@ -18,24 +18,17 @@
     <label>Patient
       <select id="appointment-patient"></select>
     </label>
-    <label>Clinician
-      <select id="appointment-clinician"></select>
-    </label>
     <label>Appointment Type
       <select id="appointment-type"></select>
+    </label>
+    <label>Clinician
+      <select id="appointment-clinician"></select>
     </label>
     <label>Location
       <select id="appointment-location"></select>
     </label>
-    <label>Duration (minutes)<input type="number" id="appointment-duration" required></label>
+    <label>Duration (minutes)<input type="number" id="appointment-duration" readonly></label>
     <label>Date & Time <input type="datetime-local" id="appointment-datetime" required></label>
-    <label>Status
-      <select id="appointment-status">
-        <option value="planned">Planned</option>
-        <option value="completed">Completed</option>
-        <option value="cancelled">Cancelled</option>
-      </select>
-    </label>
     <label>Price <input type="number" id="appointment-price" required></label>
     <button type="submit">Save</button>
   </form>

--- a/js/appointment_types.js
+++ b/js/appointment_types.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     tableBody.innerHTML = '';
     types.forEach(t => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${t.name}</td><td>${t.default_duration_minutes}</td><td><button data-id="${t.id}" data-action="edit">Edit</button> <button data-id="${t.id}" data-action="delete">Delete</button></td>`;
+      tr.innerHTML = `<td>${t.name}</td><td>${t.specialty}</td><td>${t.default_duration_minutes}</td><td><button data-id="${t.id}" data-action="edit">Edit</button> <button data-id="${t.id}" data-action="delete">Delete</button></td>`;
       tableBody.appendChild(tr);
     });
   }
@@ -16,13 +16,15 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const id = document.getElementById('type-id').value;
     const name = document.getElementById('type-name').value.trim();
+    const specialty = document.getElementById('type-specialty').value;
     const duration = parseInt(document.getElementById('type-duration').value, 10);
     if (id) {
       const t = types.find(t => t.id == id);
       t.name = name;
+      t.specialty = specialty;
       t.default_duration_minutes = duration;
     } else {
-      types.push({ id: nextId(types), name, default_duration_minutes: duration });
+      types.push({ id: nextId(types), name, specialty, default_duration_minutes: duration });
     }
     saveData('appointmentTypes', types);
     form.reset();
@@ -37,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const t = types.find(t => t.id == id);
       document.getElementById('type-id').value = t.id;
       document.getElementById('type-name').value = t.name;
+      document.getElementById('type-specialty').value = t.specialty;
       document.getElementById('type-duration').value = t.default_duration_minutes;
     } else if (action === 'delete') {
       types = types.filter(t => t.id != id);

--- a/js/appointments.js
+++ b/js/appointments.js
@@ -38,19 +38,34 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
   populate(patientSelect, patients);
-  populate(clinicianSelect, clinicians);
   populate(typeSelect, types);
+  function filterClinicians() {
+    const t = types.find(t => t.id == typeSelect.value);
+    let list = clinicians;
+    if (t) {
+      list = clinicians.filter(c => c.specialty === t.specialty);
+    }
+    populate(clinicianSelect, list);
+  }
+  filterClinicians();
+  const initialType = types.find(t => t.id == typeSelect.value);
+  if (initialType) {
+    durationInput.value = initialType.default_duration_minutes;
+  }
   populate(locationSelect, locations);
+  updatePrice();
 
   typeSelect.addEventListener('change', () => {
     const t = types.find(t => t.id == typeSelect.value);
-    if (t) durationInput.value = t.default_duration_minutes;
+    if (t) {
+      durationInput.value = t.default_duration_minutes;
+    }
+    filterClinicians();
     updatePrice();
   });
   clinicianSelect.addEventListener('change', updatePrice);
   patientSelect.addEventListener('change', updatePrice);
   locationSelect.addEventListener('change', updatePrice);
-  durationInput.addEventListener('input', updatePrice);
 
   function updatePrice() {
     const price = computePrice(typeSelect.value, patientSelect.value, clinicianSelect.value, locationSelect.value, durationInput.value);
@@ -85,13 +100,19 @@ document.addEventListener('DOMContentLoaded', () => {
       appointment_type: parseInt(typeSelect.value, 10),
       duration_minutes: parseInt(durationInput.value, 10),
       date_time: document.getElementById('appointment-datetime').value,
-      status: document.getElementById('appointment-status').value,
+      status: 'planned',
       price: parseFloat(priceInput.value)
     };
     appointments.push(appointment);
     saveData('appointments', appointments);
     form.reset();
+    filterClinicians();
+    const tReset = types.find(t => t.id == typeSelect.value);
+    if (tReset) {
+      durationInput.value = tReset.default_duration_minutes;
+    }
     form.dataset.manual = '';
+    updatePrice();
     render();
   });
 


### PR DESCRIPTION
## Summary
- add specialty field to appointment types
- include specialty column in list and editing logic
- reorder appointment form to pick type before clinician
- filter clinicians by selected type's specialty
- auto-fill duration, default appointment status, and update price on form changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d7fd59184833080012520a7038d37