### PR TITLE
Switch edit/delete buttons to icons

### DIFF
--- a/css/overrides.css
+++ b/css/overrides.css
@@ -8,3 +8,9 @@ nav ul {
   list-style: none;
   padding: 0;
 }
+
+/* smaller buttons used for table action icons */
+.icon-btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.9rem;
+}

--- a/js/appointment_types.js
+++ b/js/appointment_types.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     tableBody.innerHTML = '';
     types.forEach(t => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${t.name}</td><td>${t.specialty}</td><td>${t.default_duration_minutes}</td><td><button data-id="${t.id}" data-action="edit">Editar</button> <button data-id="${t.id}" data-action="delete">Eliminar</button></td>`;
+      tr.innerHTML = `<td>${t.name}</td><td>${t.specialty}</td><td>${t.default_duration_minutes}</td><td><button class="icon-btn" data-id="${t.id}" data-action="edit" aria-label="Editar">✏️</button> <button class="icon-btn" data-id="${t.id}" data-action="delete" aria-label="Eliminar">🗑️</button></td>`;
       tableBody.appendChild(tr);
     });
   }

--- a/js/appointments.js
+++ b/js/appointments.js
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const tr = document.createElement('tr');
       const patient = patients.find(p => p.id == a.patient_id)?.name || '';
       const clinician = clinicians.find(c => c.id == a.clinician_id)?.name || '';
-      tr.innerHTML = `<td>${patient}</td><td>${clinician}</td><td>${a.date_time}</td><td>${a.status}</td><td>${a.price}</td><td><button data-id="${a.id}" data-action="delete">Eliminar</button></td>`;
+      tr.innerHTML = `<td>${patient}</td><td>${clinician}</td><td>${a.date_time}</td><td>${a.status}</td><td>${a.price}</td><td><button class="icon-btn" data-id="${a.id}" data-action="delete" aria-label="Eliminar">🗑️</button></td>`;
       tableBody.appendChild(tr);
     });
   }

--- a/js/clinicians.js
+++ b/js/clinicians.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     tableBody.innerHTML = '';
     clinicians.forEach(c => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${c.name}</td><td>${c.specialty}</td><td><button data-id="${c.id}" data-action="edit">Editar</button> <button data-id="${c.id}" data-action="delete">Eliminar</button></td>`;
+      tr.innerHTML = `<td>${c.name}</td><td>${c.specialty}</td><td><button class="icon-btn" data-id="${c.id}" data-action="edit" aria-label="Editar">✏️</button> <button class="icon-btn" data-id="${c.id}" data-action="delete" aria-label="Eliminar">🗑️</button></td>`;
       tableBody.appendChild(tr);
     });
   }

--- a/js/locations.js
+++ b/js/locations.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
     tableBody.innerHTML = '';
     locations.forEach(l => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${l.name}</td><td><button data-id="${l.id}" data-action="edit">Editar</button> <button data-id="${l.id}" data-action="delete">Eliminar</button></td>`;
+      tr.innerHTML = `<td>${l.name}</td><td><button class="icon-btn" data-id="${l.id}" data-action="edit" aria-label="Editar">✏️</button> <button class="icon-btn" data-id="${l.id}" data-action="delete" aria-label="Eliminar">🗑️</button></td>`;
       tableBody.appendChild(tr);
     });
   }

--- a/js/patients.js
+++ b/js/patients.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     tableBody.innerHTML = '';
     patients.forEach(p => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${p.name}</td><td><button data-id="${p.id}" data-action="edit">Editar</button> <button data-id="${p.id}" data-action="delete">Eliminar</button></td>`;
+      tr.innerHTML = `<td>${p.name}</td><td><button class="icon-btn" data-id="${p.id}" data-action="edit" aria-label="Editar">✏️</button> <button class="icon-btn" data-id="${p.id}" data-action="delete" aria-label="Eliminar">🗑️</button></td>`;
       tableBody.appendChild(tr);
     });
   }


### PR DESCRIPTION
## Summary
- add `.icon-btn` CSS class for compact icon buttons
- use icon buttons on clinicians, patients, appointment types, locations and appointments tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687b84e301e883308ef94184b212832e