### PR TITLE
Fix CSS typo breaking menu

### DIFF
--- a/css/overrides.css
+++ b/css/overrides.css
@@ -21,6 +21,7 @@ nav ul {
 .icon-btn {
   padding: 0.25rem 0.5rem;
   font-size: 0.9rem;
+}
 
 #side-menu li {
   margin-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- add missing closing brace in the CSS overrides

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687b870223ac833080c5f7de4a9a8f89